### PR TITLE
feat: add missing include that fixes support for gcc13 builds

### DIFF
--- a/src/circuit/util/MaskHandler.h
+++ b/src/circuit/util/MaskHandler.h
@@ -8,6 +8,7 @@
 #ifndef SRC_CIRCUIT_UTIL_MASKHANDLER_H_
 #define SRC_CIRCUIT_UTIL_MASKHANDLER_H_
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <unordered_map>


### PR DESCRIPTION
reason: https://gcc.gnu.org/gcc-13/porting_to.html#:~:text=The%20following%20headers%20are%20used%20less%20widely%20in%20libstdc%2B%2B%20and%20may%20need%20to%20be%20included%20explicitly%20when%20compiling%20with%20GCC%2013%3A