### PR TITLE
Detect the new ZK mex customparam

### DIFF
--- a/src/circuit/module/EconomyManager.cpp
+++ b/src/circuit/module/EconomyManager.cpp
@@ -216,7 +216,8 @@ CEconomyManager::CEconomyManager(CCircuitAI* circuit)
 				// BA: float metalConverts = unitDef->GetMakesResource(metalRes);
 				//     float metalExtracts = unitDef->GetExtractsResource(metalRes);
 				//     float netMetal = unitDef->GetResourceMake(metalRes) - unitDef->GetUpkeep(metalRes);
-				if (((it = customParams.find("ismex")) != customParams.end()) && (utils::string_to_int(it->second) == 1)) {
+				if (((it = customParams.find(               "ismex")) != customParams.end()) && (utils::string_to_int(it->second) == 1)
+				||  ((it = customParams.find("metal_extractor_mult")) != customParams.end()) && (utils::string_to_int(it->second) > 0)) {
 					finishedHandler[cdef.GetId()] = mexFinishedHandler;
 					mexDef = &cdef;  // cormex
 					cdef.SetIsMex(true);


### PR DESCRIPTION
`metal_extraction_mult` is a multiplier so perhaps in the future there could also be some logic to pick the "best" mex type if multiple are available.

For now, just detect it as a valid mex.