### PR TITLE
Build angelscript arm64 calling-convention asm on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,16 @@ if(MSVC AND NOT IS_ARM64_BUILD)
 		message(FATAL ERROR "MSVC x86_64 target requires a working assembler")
 	endif()
 endif()
+
+# angelscript native calling convention for arm64 needs a hand-written assembly
+# stub (CallARM64 et al.). The C/C++ source glob never picks up the .S file, so
+# add it explicitly. macOS/Mach-O needs the xcode variant (underscore-mangled
+# symbols) regardless of compiler; the generic glob handles the .cpp half.
+if (APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")
+	enable_language(ASM)
+	set(additionalSources  ${additionalSources} ${CMAKE_CURRENT_SOURCE_DIR}/src/lib/angelscript/source/as_callfunc_arm64_xcode.S)
+endif ()
+
 set(additionalLibraries    ${Cpp_AIWRAPPER_TARGET} CUtils)  # can't use Tracy::TracyClient in dll, requires -fPIC
 
 if (MSVC)


### PR DESCRIPTION
## Problem

Building the BARb Skirmish AI on macOS / Apple Silicon (arm64) fails at link:

```
Undefined symbols for architecture arm64:
  "_CallARM64", "_CallARM64Double", "_CallARM64Float", "_CallARM64Ret128",
  "_CallARM64RetInMemory", "_GetHFAReturnDouble", "_GetHFAReturnFloat"
    referenced from: CallSystemFunctionNative(...) in as_callfunc_arm64.cpp.o
```

On arm64, angelscript's `as_config.h` enables the native calling convention
(`AS_ARM64`), so `as_callfunc_arm64.cpp` references the `CallARM64` / `GetHFAReturn*`
symbols. Those are defined in a hand-written assembly stub
(`as_callfunc_arm64_xcode.S`), but the Skirmish AI source glob only collects
C/C++ sources, so no `.S` is ever compiled and the symbols are undefined.

(This only affects arm64; on x86_64 angelscript uses inline-asm `.cpp`, which the
glob already picks up — so this never surfaced on the usual Linux/x86_64 builds.)

## Fix

On `APPLE AND arm64`, `enable_language(ASM)` and add
`src/lib/angelscript/source/as_callfunc_arm64_xcode.S` to the sources.

The **xcode** variant is required (not `_gcc.S`) because Mach-O prefixes symbols
with a leading underscore (`_CallARM64`) regardless of compiler — it's an object
format concern, not a compiler one.

## Verification

Built on macOS / Apple Silicon with Homebrew GCC 16: `as_callfunc_arm64_xcode.S`
compiles, `SkirmishAI.dylib` links with no undefined symbols, and the engine's
`spring-headless` links cleanly with the AIs enabled (`-DAI_TYPES=NATIVE`).

---
*Assisted by Claude Code; verified by building on macOS.*